### PR TITLE
Fixes argparse error (and consistency cleanup)

### DIFF
--- a/scripts/ci-bot.py
+++ b/scripts/ci-bot.py
@@ -14,7 +14,11 @@ parser.add_argument(
     help="Frequency at which to check for new ommits to test",
     type=int,
     default=5)
-parser.add_argument("-t","--test-on-start",action=store_true,default=False,help="Run test on commits at startup")
+parser.add_argument("-t",
+    "--test-on-start",
+    action="store_true",
+    default=False,
+    help="Run test on commits at startup")
 parser.add_argument(
     "-p",
     "--project-file",


### PR DESCRIPTION
This is just a minor fix so that `ci-bot -h` will work.  Made the code line consistent with below for simplicity.